### PR TITLE
Add device type detection for type iPhone5,2 (iPhone 5 model A1429)

### DIFF
--- a/System Services/Utilities/SSHardwareInfo.m
+++ b/System Services/Utilities/SSHardwareInfo.m
@@ -138,6 +138,8 @@
                 NewDeviceType = @"iPhone 4S";
             else if ([DeviceType isEqualToString:@"iPhone5,1"])
                 NewDeviceType = @"iPhone 5";
+            else if ([DeviceType isEqualToString:@"iPhone5,2"])
+                NewDeviceType = @"iPhone 5";
             else if ([DeviceType isEqualToString:@"iPod1,1"])
                 NewDeviceType = @"1st Gen iPod";
             else if ([DeviceType isEqualToString:@"iPod2,1"])


### PR DESCRIPTION
Hi,
iPhone5,2 is the European model (A1429)
More: http://stackoverflow.com/a/12538939

David
